### PR TITLE
Fixed countly initialization for the TitaniumProxyService

### DIFF
--- a/android/src/count/ly/messaging/TitaniumProxyService.java
+++ b/android/src/count/ly/messaging/TitaniumProxyService.java
@@ -50,44 +50,44 @@ public class TitaniumProxyService extends IntentService {
             	Log.d(TAG, "Got a message from intent: " + intentMessage);
             	
             	
-            	// Create HashMap of Notification info and add data
-				HashMap pushMessage = new HashMap();
-				pushMessage.put("id", intentMessage.getId());
-				pushMessage.put("message", intentMessage.getNotificationMessage());
-				
-				if (intentMessage.hasLink()){
-					pushMessage.put("type", "hasLink");
-					pushMessage.put("link", intentMessage.getLink());
-				}else if (intentMessage.hasReview()){
-					pushMessage.put("type", "hasReview");
-				}else if (intentMessage.hasMessage()) {
-					pushMessage.put("type", "hasMessage");
-				}
-				
-				if (intentMessage.hasSoundUri()){
-					pushMessage.put("sound", intentMessage.getSoundUri());
-				}
-				
-				pushMessage.put("data", bundleToHashMap(intentMessage.getData()));						
-				
-				// log pushMessage HashMap
-				Log.d(TAG, "pushMessage HashMap: " + pushMessage);
-				
-				// Set pushMessage into TiProperties
-				TiProperties appProperties = TiApplication.getInstance().getAppProperties();
-				appProperties.setString("pushMessage", TiConvert.toJSONString(pushMessage));	 
-				
-				// Create the Intent to launch the App
-				Intent launch = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
-				intent.addCategory("android.intent.category.LAUNCHER");
-				launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
-				
-				// Run Intent to Launch App
-				getApplicationContext().startActivity(launch);	
+            // Create HashMap of Notification info and add data
+			HashMap pushMessage = new HashMap();
+			pushMessage.put("id", intentMessage.getId());
+			pushMessage.put("message", intentMessage.getNotificationMessage());
+			
+			if (intentMessage.hasLink()){
+				pushMessage.put("type", "hasLink");
+				pushMessage.put("link", intentMessage.getLink());
+			}else if (intentMessage.hasReview()){
+				pushMessage.put("type", "hasReview");
+			}else if (intentMessage.hasMessage()) {
+				pushMessage.put("type", "hasMessage");
+			}
+			
+			if (intentMessage.hasSoundUri()){
+				pushMessage.put("sound", intentMessage.getSoundUri());
+			}
+			
+			pushMessage.put("data", bundleToHashMap(intentMessage.getData()));						
+			
+			// log pushMessage HashMap
+			Log.d(TAG, "pushMessage HashMap: " + pushMessage);
+			
+			// Set pushMessage into TiProperties
+			TiProperties appProperties = TiApplication.getInstance().getAppProperties();
+			appProperties.setString("pushMessage", TiConvert.toJSONString(pushMessage));	 
+			
+			// Create the Intent to launch the App
+			Intent launch = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
+			intent.addCategory("android.intent.category.LAUNCHER");
+			launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
+			
+			// Run Intent to Launch App
+			getApplicationContext().startActivity(launch);	
 
 
-				//Make sure we have countly initialized before recording the message event.
-				if (!Countly.sharedInstance().isInitialized()) {
+			//Make sure we have countly initialized before recording the message event.
+			if (!Countly.sharedInstance().isInitialized()) {
                     if (!CountlyMessaging.initCountly(getApplicationContext())) {
                         Log.e(TAG, "Cannot init Countly in background");
                     } else { 	

--- a/android/src/count/ly/messaging/TitaniumProxyService.java
+++ b/android/src/count/ly/messaging/TitaniumProxyService.java
@@ -50,44 +50,44 @@ public class TitaniumProxyService extends IntentService {
             	Log.d(TAG, "Got a message from intent: " + intentMessage);
             	
             	
-            // Create HashMap of Notification info and add data
-			HashMap pushMessage = new HashMap();
-			pushMessage.put("id", intentMessage.getId());
-			pushMessage.put("message", intentMessage.getNotificationMessage());
-			
-			if (intentMessage.hasLink()){
-				pushMessage.put("type", "hasLink");
-				pushMessage.put("link", intentMessage.getLink());
-			}else if (intentMessage.hasReview()){
-				pushMessage.put("type", "hasReview");
-			}else if (intentMessage.hasMessage()) {
-				pushMessage.put("type", "hasMessage");
-			}
-			
-			if (intentMessage.hasSoundUri()){
-				pushMessage.put("sound", intentMessage.getSoundUri());
-			}
-			
-			pushMessage.put("data", bundleToHashMap(intentMessage.getData()));						
-			
-			// log pushMessage HashMap
-			Log.d(TAG, "pushMessage HashMap: " + pushMessage);
-			
-			// Set pushMessage into TiProperties
-			TiProperties appProperties = TiApplication.getInstance().getAppProperties();
-			appProperties.setString("pushMessage", TiConvert.toJSONString(pushMessage));	 
-			
-			// Create the Intent to launch the App
-			Intent launch = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
-			intent.addCategory("android.intent.category.LAUNCHER");
-			launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
-			
-			// Run Intent to Launch App
-			getApplicationContext().startActivity(launch);	
+				// Create HashMap of Notification info and add data
+				HashMap pushMessage = new HashMap();
+				pushMessage.put("id", intentMessage.getId());
+				pushMessage.put("message", intentMessage.getNotificationMessage());
+				
+				if (intentMessage.hasLink()){
+					pushMessage.put("type", "hasLink");
+					pushMessage.put("link", intentMessage.getLink());
+				}else if (intentMessage.hasReview()){
+					pushMessage.put("type", "hasReview");
+				}else if (intentMessage.hasMessage()) {
+					pushMessage.put("type", "hasMessage");
+				}
+				
+				if (intentMessage.hasSoundUri()){
+					pushMessage.put("sound", intentMessage.getSoundUri());
+				}
+				
+				pushMessage.put("data", bundleToHashMap(intentMessage.getData()));						
+				
+				// log pushMessage HashMap
+				Log.d(TAG, "pushMessage HashMap: " + pushMessage);
+				
+				// Set pushMessage into TiProperties
+				TiProperties appProperties = TiApplication.getInstance().getAppProperties();
+				appProperties.setString("pushMessage", TiConvert.toJSONString(pushMessage));	 
+				
+				// Create the Intent to launch the App
+				Intent launch = getApplicationContext().getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
+				intent.addCategory("android.intent.category.LAUNCHER");
+				launch.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
+				
+				// Run Intent to Launch App
+				getApplicationContext().startActivity(launch);	
 
 
-			//Make sure we have countly initialized before recording the message event.
-			if (!Countly.sharedInstance().isInitialized()) {
+				//Make sure we have countly initialized before recording the message event.
+				if (!Countly.sharedInstance().isInitialized()) {
                     if (!CountlyMessaging.initCountly(getApplicationContext())) {
                         Log.e(TAG, "Cannot init Countly in background");
                     } else { 	

--- a/android/src/count/ly/messaging/TitaniumProxyService.java
+++ b/android/src/count/ly/messaging/TitaniumProxyService.java
@@ -49,8 +49,6 @@ public class TitaniumProxyService extends IntentService {
             if (intentMessage.isValid()) {
             	Log.d(TAG, "Got a message from intent: " + intentMessage);
             	
-            	// mark message open
-            	CountlyMessaging.recordMessageOpen(intentMessage.getId());
             	
             	// Create HashMap of Notification info and add data
 				HashMap pushMessage = new HashMap();
@@ -86,6 +84,16 @@ public class TitaniumProxyService extends IntentService {
 				
 				// Run Intent to Launch App
 				getApplicationContext().startActivity(launch);	
+
+
+				//Make sure we have countly initialized before recording the message event.
+				if (!Countly.sharedInstance().isInitialized()) {
+                    if (!CountlyMessaging.initCountly(getApplicationContext())) {
+                        Log.e(TAG, "Cannot init Countly in background");
+                    } else { 	
+                    	Log.e(TAG, "Countly initialized");
+                    }
+                }
 				
 				// Set TitaniumCountlyAndroidMessagingModule.message
 	            TitaniumCountlyAndroidMessagingModule.message = intentMessage;
@@ -94,6 +102,9 @@ public class TitaniumProxyService extends IntentService {
 	            // if application was just in background this will process the notification
 	            // else application will start and check TiProperties for pushMessage on startup
 				TitaniumCountlyAndroidMessagingModule.processPushCallBack();
+
+				// mark message open
+            	CountlyMessaging.recordMessageOpen(intentMessage.getId());
 				
             }else{
             	Log.d(TAG, "No Valid Message Found");


### PR DESCRIPTION
TitaniumProxyService is responsible for handling Intents when a push notification is opened.

This service utilizes `CountlyMessaging.recordMessageOpen(msg.id)` which requires application context in order to properly retrieve the shared preferences needed.
If countly is not initialized before this method is called, the application context is null which produces the following error:

`FATAL EXCEPTION: IntentService[CountlyTitaniumProxyService]
                                                 Process: com.fanhero.develop, PID: 4820
                                                 java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.SharedPreferences android.content.Context.getSharedPreferences(java.lang.String, int)' on a null object reference
                                                     at count.ly.messaging.CountlyMessaging.getGCMPreferences(CountlyMessaging.java:219)
                                                     at count.ly.messaging.CountlyMessaging.initCountly(CountlyMessaging.java:168)
                                                     at count.ly.messaging.CountlyMessaging.recordMessageOpen(CountlyMessaging.java:284)
                                                     at count.ly.messaging.TitaniumProxyService.onHandleIntent(TitaniumProxyService.java:53)
                                                     at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
                                                     at android.os.Handler.dispatchMessage(Handler.java:102)
                                                     at android.os.Looper.loop(Looper.java:158)
                                                     at android.os.HandlerThread.run(HandlerThread.java:61)` 

By checking the initialization of the messaging  module before call `CountlyMessaging.recordMessageOpen(msg.id)` we can obtain proper context before recording the notification event.  
